### PR TITLE
Add support for bitswap check getting the block itself

### DIFF
--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -21,7 +21,7 @@ type BsCheckOutput struct {
 	Error     error
 }
 
-func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr) (*BsCheckOutput, error) {
+func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr, getBlock bool) (*BsCheckOutput, error) {
 	h, err := libp2pHost()
 	if err != nil {
 		return nil, err
@@ -45,7 +45,12 @@ func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr) (*B
 
 	bs := bsnet.NewFromIpfsHost(h, nilRouter)
 	msg := bsmsg.New(false)
-	msg.AddEntry(c, 0, bsmsgpb.Message_Wantlist_Have, true)
+
+	wantType := bsmsgpb.Message_Wantlist_Have
+	if getBlock {
+		wantType = bsmsgpb.Message_Wantlist_Block
+	}
+	msg.AddEntry(c, 0, wantType, true)
 
 	rcv := &bsReceiver{
 		target: target,

--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -2,6 +2,7 @@ package vole
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -20,6 +21,26 @@ type BsCheckOutput struct {
 	Responded bool
 	Error     error
 }
+
+func (o *BsCheckOutput) MarshalJSON() ([]byte, error) {
+	var errorMsg *string
+	if o.Error != nil {
+		m := o.Error.Error()
+		errorMsg = &m
+	}
+	anon := struct {
+		Found     bool
+		Responded bool
+		Error     *string
+	}{
+		Found:     o.Found,
+		Responded: o.Responded,
+		Error:     errorMsg,
+	}
+	return json.Marshal(anon)
+}
+
+var _ json.Marshaler = (*BsCheckOutput)(nil)
 
 func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr, getBlock bool) (*BsCheckOutput, error) {
 	h, err := libp2pHost()

--- a/lib/bitswap_test.go
+++ b/lib/bitswap_test.go
@@ -48,7 +48,7 @@ func TestBitswapCheckPresent(t *testing.T) {
 
 	_ = bitswap.New(ctx, bsnetwork, bstore)
 
-	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0])
+	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0], true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestBitswapCheckNotPresent(t *testing.T) {
 
 	_ = bitswap.New(ctx, bsnetwork, bstore)
 
-	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0])
+	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0], true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -375,6 +375,7 @@ var bitswapCheckCmd = &cli.Command{
 		}
 		cidStr := c.Args().Get(0)
 		maStr := c.Args().Get(1)
+		getBlock := c.Bool("get-block")
 
 		bsCid, err := cid.Decode(cidStr)
 		if err != nil {
@@ -386,7 +387,7 @@ var bitswapCheckCmd = &cli.Command{
 			return err
 		}
 
-		output, err := vole.CheckBitswapCID(c.Context, bsCid, ma)
+		output, err := vole.CheckBitswapCID(c.Context, bsCid, ma, getBlock)
 		if err != nil {
 			return err
 		}
@@ -398,5 +399,13 @@ var bitswapCheckCmd = &cli.Command{
 		fmt.Printf("%s\n", jsOut)
 
 		return nil
+	},
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "get-block",
+			Usage:       "get the block",
+			Value:       true,
+			DefaultText: "true",
+		},
 	},
 }


### PR DESCRIPTION
This covers use cases where even though the peer says it has the block it can't/won't transfer it. For example, if the block is too big to transfer.

Also fixes an issue with encoding errors as json